### PR TITLE
Make Column letter functions public

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -25,7 +25,7 @@ func (e *XLSXReaderError) Error() string {
 
 // getRangeFromString is an internal helper function that converts
 // XLSX internal range syntax to a pair of integers.  For example,
-// the range string "1:3" yield the upper and lower intergers 1 and 3.
+// the range string "1:3" yield the upper and lower integers 1 and 3.
 func getRangeFromString(rangeString string) (lower int, upper int, error error) {
 	var parts []string
 	parts = strings.SplitN(rangeString, ":", 2)
@@ -46,9 +46,9 @@ func getRangeFromString(rangeString string) (lower int, upper int, error error) 
 	return lower, upper, error
 }
 
-// lettersToNumeric is used to convert a character based column
+// ColLettersToIndex is used to convert a character based column
 // reference to a zero based numeric column identifier.
-func lettersToNumeric(letters string) int {
+func ColLettersToIndex(letters string) int {
 	sum, mul, n := 0, 1, 0
 	for i := len(letters) - 1; i >= 0; i, mul, n = i-1, mul*26, 1 {
 		c := letters[i]
@@ -134,9 +134,9 @@ func intToBase26(x int) (parts []int) {
 	return parts
 }
 
-// numericToLetters is used to convert a zero based, numeric column
+// ColIndexToLetters is used to convert a zero based, numeric column
 // indentifier into a character code.
-func numericToLetters(colRef int) string {
+func ColIndexToLetters(colRef int) string {
 	parts := intToBase26(colRef)
 	return formatColumnName(smooshBase26Slice(parts))
 }
@@ -172,14 +172,14 @@ func GetCoordsFromCellIDString(cellIDString string) (x, y int, error error) {
 		return x, y, error
 	}
 	y -= 1 // Zero based
-	x = lettersToNumeric(letterPart)
+	x = ColLettersToIndex(letterPart)
 	return x, y, error
 }
 
 // GetCellIDStringFromCoords returns the Excel format cell name that
 // represents a pair of zero based cartesian coordinates.
 func GetCellIDStringFromCoords(x, y int) string {
-	letterPart := numericToLetters(x)
+	letterPart := ColIndexToLetters(x)
 	numericPart := y + 1
 	return fmt.Sprintf("%s%d", letterPart, numericPart)
 }

--- a/lib_test.go
+++ b/lib_test.go
@@ -141,7 +141,7 @@ func (l *LibSuite) TestLettersToNumeric(c *C) {
 		"BA": 52, "BZ": 77, "ZA": 26*26 + 0, "ZZ": 26*26 + 25,
 		"AAA": 26*26 + 26 + 0, "AMI": 1022}
 	for input, ans := range cases {
-		output := lettersToNumeric(input)
+		output := ColLettersToIndex(input)
 		c.Assert(output, Equals, ans)
 	}
 }
@@ -158,7 +158,7 @@ func (l *LibSuite) TestNumericToLetters(c *C) {
 		"ZZ":  26*26 + 25,
 		"AAA": 26*26 + 26 + 0, "AMI": 1022}
 	for ans, input := range cases {
-		output := numericToLetters(input)
+		output := ColIndexToLetters(input)
 		c.Assert(output, Equals, ans)
 	}
 

--- a/sheet.go
+++ b/sheet.go
@@ -129,7 +129,7 @@ func (s *Sheet) handleMerged() {
 	for r, row := range s.Rows {
 		for c, cell := range row.Cells {
 			if cell.HMerge > 0 || cell.VMerge > 0 {
-				coord := fmt.Sprintf("%s%d", numericToLetters(c), r+1)
+				coord := GetCellIDStringFromCoords(c, r)
 				merged[coord] = cell
 			}
 		}
@@ -288,7 +288,7 @@ func (s *Sheet) makeXLSXSheet(refTable *RefTable, styles *xlsxStyleSheet) *xlsxW
 				maxCell = c
 			}
 			xC := xlsxC{}
-			xC.R = fmt.Sprintf("%s%d", numericToLetters(c), r+1)
+			xC.R = GetCellIDStringFromCoords(c, r)
 			switch cell.cellType {
 			case CellTypeString:
 				if len(cell.Value) > 0 {
@@ -325,10 +325,10 @@ func (s *Sheet) makeXLSXSheet(refTable *RefTable, styles *xlsxStyleSheet) *xlsxW
 			if cell.HMerge > 0 || cell.VMerge > 0 {
 				// r == rownum, c == colnum
 				mc := xlsxMergeCell{}
-				start := fmt.Sprintf("%s%d", numericToLetters(c), r+1)
-				endcol := c + cell.HMerge
-				endrow := r + cell.VMerge + 1
-				end := fmt.Sprintf("%s%d", numericToLetters(endcol), endrow)
+				start := GetCellIDStringFromCoords(c, r)
+				endCol := c + cell.HMerge
+				endRow := r + cell.VMerge
+				end := GetCellIDStringFromCoords(endCol, endRow)
 				mc.Ref = start + ":" + end
 				if worksheet.MergeCells == nil {
 					worksheet.MergeCells = &xlsxMergeCells{}
@@ -356,8 +356,7 @@ func (s *Sheet) makeXLSXSheet(refTable *RefTable, styles *xlsxStyleSheet) *xlsxW
 
 	worksheet.SheetData = xSheet
 	dimension := xlsxDimension{}
-	dimension.Ref = fmt.Sprintf("A1:%s%d",
-		numericToLetters(maxCell), maxRow+1)
+	dimension.Ref = "A1:" + GetCellIDStringFromCoords(maxCell, maxRow)
 	if dimension.Ref == "A1:A1" {
 		dimension.Ref = "A1"
 	}


### PR DESCRIPTION
We need ColIndexToLetters so that we can produce error messages that reference the column where the error occurs.